### PR TITLE
Changes for auto deploy on gh-pages branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Find some useful links below:
 
 ## Latest API Docs
 
-Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-keyvalue/api/1.0.1-SNAPSHOT">1.0.1-SNAPSHOT</a>.
+Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-keyvalue/api/1.0.2-SNAPSHOT">1.0.2-SNAPSHOT</a>.
 
 ## How to use
 
@@ -46,8 +46,8 @@ Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/si
 
 ## Features
 
-* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-keyvalue/api/1.0.1-SNAPSHOT/#keyvalue-sink-mapper">keyvalue</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#sink-mappers">Sink Mapper</a>)*<br><div style="padding-left: 1em;"><p>The <code>Event to Key-Value Map</code> output mapper extension allows you to convert Siddhi events processed by WSO2 SP to key-value map events before publishing them. You can either use pre-defined keys where conversion takes place without extra configurations, or use custom keys with which the messages can be published.</p></div>
-* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-keyvalue/api/1.0.1-SNAPSHOT/#keyvalue-source-mapper">keyvalue</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#source-mappers">Source Mapper</a>)*<br><div style="padding-left: 1em;"><p><code>Key-Value Map to Event</code> input mapper extension allows transports that accept events as key value maps to convert those events to Siddhi events. You can either receive pre-defined keys where conversion takes place without extra configurations, or use custom keys to map from the message.</p></div>
+* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-keyvalue/api/1.0.2-SNAPSHOT/#keyvalue-source-mapper">keyvalue</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#source-mappers">Source Mapper</a>)*<br><div style="padding-left: 1em;"><p><code>Key-Value Map to Event</code> input mapper extension allows transports that accept events as key value maps to convert those events to Siddhi events. You can either receive pre-defined keys where conversion takes place without extra configurations, or use custom keys to map from the message.</p></div>
+* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-keyvalue/api/1.0.2-SNAPSHOT/#keyvalue-sink-mapper">keyvalue</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#sink-mappers">Sink Mapper</a>)*<br><div style="padding-left: 1em;"><p>The <code>Event to Key-Value Map</code> output mapper extension allows you to convert Siddhi events processed by WSO2 SP to key-value map events before publishing them. You can either use pre-defined keys where conversion takes place without extra configurations, or use custom keys with which the messages can be published.</p></div>
 
 ## How to Contribute
 

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -18,7 +18,8 @@
   ~ under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.wso2.extension.siddhi.map.keyvalue</groupId>
         <artifactId>siddhi-map-keyvalue-parent</artifactId>
@@ -66,7 +67,28 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
+    <profiles>
+        <profile>
+            <id>documentation-deploy</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wso2.siddhi</groupId>
+                        <artifactId>siddhi-doc-gen</artifactId>
+                        <version>${siddhi.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>deploy-mkdocs-github-pages</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
     <build>
         <plugins>
             <plugin>
@@ -137,6 +159,19 @@
                             <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut
                             </outputDirectory>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.wso2.siddhi</groupId>
+                <artifactId>siddhi-doc-gen</artifactId>
+                <version>${siddhi.version}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>generate-md-docs</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/docs/api/1.0.2-SNAPSHOT.md
+++ b/docs/api/1.0.2-SNAPSHOT.md
@@ -1,0 +1,87 @@
+# API Docs - v1.0.2-SNAPSHOT
+
+## Sourcemapper
+
+### keyvalue *<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#source-mapper">(Source Mapper)</a>*
+
+<p style="word-wrap: break-word"><code>Key-Value Map to Event</code> input mapper extension allows transports that accept events as key value maps to convert those events to Siddhi events. You can either receive pre-defined keys where conversion takes place without extra configurations, or use custom keys to map from the message.</p>
+
+<span id="syntax" class="md-typeset" style="display: block; font-weight: bold;">Syntax</span>
+```
+@source(..., @map(type="keyvalue", fail.on.missing.attribute="<BOOL>")
+```
+
+<span id="query-parameters" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">QUERY PARAMETERS</span>
+<table>
+    <tr>
+        <th>Name</th>
+        <th style="min-width: 20em">Description</th>
+        <th>Default Value</th>
+        <th>Possible Data Types</th>
+        <th>Optional</th>
+        <th>Dynamic</th>
+    </tr>
+    <tr>
+        <td style="vertical-align: top">fail.on.missing.attribute</td>
+        <td style="vertical-align: top; word-wrap: break-word"> If this parameter is set to <code>true</code>, if an event arrives without a matching key for a specific attribute in the connected stream, it is dropped and not processed by the Stream Processor. If this parameter is set to <code>false</code> the Stream Processor adds the required key to such events with a null value, and the event is converted to a Siddhi event so that you could handle them as required before they are further processed.</td>
+        <td style="vertical-align: top">true</td>
+        <td style="vertical-align: top">BOOL</td>
+        <td style="vertical-align: top">Yes</td>
+        <td style="vertical-align: top">No</td>
+    </tr>
+</table>
+
+<span id="examples" class="md-typeset" style="display: block; font-weight: bold;">Examples</span>
+<span id="example-1" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">EXAMPLE 1</span>
+```
+@source(type='inMemory', topic='stock', @map(type='keyvalue'))
+define stream FooStream (symbol string, price float, volume long);
+
+```
+<p style="word-wrap: break-word">This query performs a default key value input mapping. The expected input is a map similar to the following:<br>symbol: 'WSO2'<br>price: 55.6f<br>volume: 100</p>
+
+<span id="example-2" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">EXAMPLE 2</span>
+```
+@source(type='inMemory', topic='stock', @map(type='keyvalue', fail.on.missing.attribute='true', @attributes(symbol = 's', price = 'p', volume = 'v')))define stream FooStream (symbol string, price float, volume long); 
+```
+<p style="word-wrap: break-word">This query performs a custom key value input mapping. The matching keys for the <code>symbol</code>, <code>price</code> and <code>volume</code> attributes are be <code>s</code>, <code>p, and </code>v` respectively.  The expected input is a map similar to the following:
+s: 'WSO2'
+p: 55.6
+v: 100</p>
+
+## Sinkmapper
+
+### keyvalue *<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#sink-mapper">(Sink Mapper)</a>*
+
+<p style="word-wrap: break-word">The <code>Event to Key-Value Map</code> output mapper extension allows you to convert Siddhi events processed by WSO2 SP to key-value map events before publishing them. You can either use pre-defined keys where conversion takes place without extra configurations, or use custom keys with which the messages can be published.</p>
+
+<span id="syntax" class="md-typeset" style="display: block; font-weight: bold;">Syntax</span>
+```
+@sink(..., @map(type="keyvalue")
+```
+
+<span id="examples" class="md-typeset" style="display: block; font-weight: bold;">Examples</span>
+<span id="example-1" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">EXAMPLE 1</span>
+```
+@sink(type='inMemory', topic='stock', @map(type='keyvalue'))
+define stream FooStream (symbol string, price float, volume long);
+
+```
+<p style="word-wrap: break-word">This query performs a default Key-Value output mapping. The expected output is something similar to the following:symbol:'WSO2'<br>price : 55.6f<br>volume: 100L</p>
+
+<span id="example-2" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">EXAMPLE 2</span>
+```
+@sink(type='inMemory', topic='stock', @map(type='keyvalue', @payload(a='symbol',b='price',c='volume')))
+define stream FooStream (symbol string, price float, volume long);
+
+```
+<p style="word-wrap: break-word">This query performs a custom Key-Value output mapping where values are passed as objects. Values for <code>symbol</code>, <code>price</code>, and <code>volume</code> attributes are published with the keys <code>a</code>, <code>b</code> and <code>c</code> respectively. The expected output is a map similar to the following:<br>a:'WSO2'<br>b : 55.6f<br>c: 100L</p>
+
+<span id="example-3" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">EXAMPLE 3</span>
+```
+@sink(type='inMemory', topic='stock', @map(type='keyvalue', @payload(a='{{symbol}} is here',b='`price`',c='volume')))
+define stream FooStream (symbol string, price float, volume long);
+
+```
+<p style="word-wrap: break-word">This query performs a custom Key-Value output mapping where the values of the <code>a</code> and <code>b</code> attributes are strings and c is object. The expected output should be a Map similar to the following:a:'WSO2 is here'<br>b : 'price'<br>c: 100L</p>
+

--- a/docs/api/latest.md
+++ b/docs/api/latest.md
@@ -1,0 +1,87 @@
+# API Docs - v1.0.2-SNAPSHOT
+
+## Sourcemapper
+
+### keyvalue *<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#source-mapper">(Source Mapper)</a>*
+
+<p style="word-wrap: break-word"><code>Key-Value Map to Event</code> input mapper extension allows transports that accept events as key value maps to convert those events to Siddhi events. You can either receive pre-defined keys where conversion takes place without extra configurations, or use custom keys to map from the message.</p>
+
+<span id="syntax" class="md-typeset" style="display: block; font-weight: bold;">Syntax</span>
+```
+@source(..., @map(type="keyvalue", fail.on.missing.attribute="<BOOL>")
+```
+
+<span id="query-parameters" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">QUERY PARAMETERS</span>
+<table>
+    <tr>
+        <th>Name</th>
+        <th style="min-width: 20em">Description</th>
+        <th>Default Value</th>
+        <th>Possible Data Types</th>
+        <th>Optional</th>
+        <th>Dynamic</th>
+    </tr>
+    <tr>
+        <td style="vertical-align: top">fail.on.missing.attribute</td>
+        <td style="vertical-align: top; word-wrap: break-word"> If this parameter is set to <code>true</code>, if an event arrives without a matching key for a specific attribute in the connected stream, it is dropped and not processed by the Stream Processor. If this parameter is set to <code>false</code> the Stream Processor adds the required key to such events with a null value, and the event is converted to a Siddhi event so that you could handle them as required before they are further processed.</td>
+        <td style="vertical-align: top">true</td>
+        <td style="vertical-align: top">BOOL</td>
+        <td style="vertical-align: top">Yes</td>
+        <td style="vertical-align: top">No</td>
+    </tr>
+</table>
+
+<span id="examples" class="md-typeset" style="display: block; font-weight: bold;">Examples</span>
+<span id="example-1" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">EXAMPLE 1</span>
+```
+@source(type='inMemory', topic='stock', @map(type='keyvalue'))
+define stream FooStream (symbol string, price float, volume long);
+
+```
+<p style="word-wrap: break-word">This query performs a default key value input mapping. The expected input is a map similar to the following:<br>symbol: 'WSO2'<br>price: 55.6f<br>volume: 100</p>
+
+<span id="example-2" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">EXAMPLE 2</span>
+```
+@source(type='inMemory', topic='stock', @map(type='keyvalue', fail.on.missing.attribute='true', @attributes(symbol = 's', price = 'p', volume = 'v')))define stream FooStream (symbol string, price float, volume long); 
+```
+<p style="word-wrap: break-word">This query performs a custom key value input mapping. The matching keys for the <code>symbol</code>, <code>price</code> and <code>volume</code> attributes are be <code>s</code>, <code>p, and </code>v` respectively.  The expected input is a map similar to the following:
+s: 'WSO2'
+p: 55.6
+v: 100</p>
+
+## Sinkmapper
+
+### keyvalue *<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#sink-mapper">(Sink Mapper)</a>*
+
+<p style="word-wrap: break-word">The <code>Event to Key-Value Map</code> output mapper extension allows you to convert Siddhi events processed by WSO2 SP to key-value map events before publishing them. You can either use pre-defined keys where conversion takes place without extra configurations, or use custom keys with which the messages can be published.</p>
+
+<span id="syntax" class="md-typeset" style="display: block; font-weight: bold;">Syntax</span>
+```
+@sink(..., @map(type="keyvalue")
+```
+
+<span id="examples" class="md-typeset" style="display: block; font-weight: bold;">Examples</span>
+<span id="example-1" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">EXAMPLE 1</span>
+```
+@sink(type='inMemory', topic='stock', @map(type='keyvalue'))
+define stream FooStream (symbol string, price float, volume long);
+
+```
+<p style="word-wrap: break-word">This query performs a default Key-Value output mapping. The expected output is something similar to the following:symbol:'WSO2'<br>price : 55.6f<br>volume: 100L</p>
+
+<span id="example-2" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">EXAMPLE 2</span>
+```
+@sink(type='inMemory', topic='stock', @map(type='keyvalue', @payload(a='symbol',b='price',c='volume')))
+define stream FooStream (symbol string, price float, volume long);
+
+```
+<p style="word-wrap: break-word">This query performs a custom Key-Value output mapping where values are passed as objects. Values for <code>symbol</code>, <code>price</code>, and <code>volume</code> attributes are published with the keys <code>a</code>, <code>b</code> and <code>c</code> respectively. The expected output is a map similar to the following:<br>a:'WSO2'<br>b : 55.6f<br>c: 100L</p>
+
+<span id="example-3" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">EXAMPLE 3</span>
+```
+@sink(type='inMemory', topic='stock', @map(type='keyvalue', @payload(a='{{symbol}} is here',b='`price`',c='volume')))
+define stream FooStream (symbol string, price float, volume long);
+
+```
+<p style="word-wrap: break-word">This query performs a custom Key-Value output mapping where the values of the <code>a</code> and <code>b</code> attributes are strings and c is object. The expected output should be a Map similar to the following:a:'WSO2 is here'<br>b : 'price'<br>c: 100L</p>
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Find some useful links below:
 
 ## Latest API Docs
 
-Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-keyvalue/api/1.0.1-SNAPSHOT">1.0.1-SNAPSHOT</a>.
+Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-keyvalue/api/1.0.2-SNAPSHOT">1.0.2-SNAPSHOT</a>.
 
 ## How to use
 
@@ -46,8 +46,8 @@ Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/si
 
 ## Features
 
-* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-keyvalue/api/1.0.1-SNAPSHOT/#keyvalue-sink-mapper">keyvalue</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#sink-mappers">Sink Mapper</a>)*<br><div style="padding-left: 1em;"><p>The <code>Event to Key-Value Map</code> output mapper extension allows you to convert Siddhi events processed by WSO2 SP to key-value map events before publishing them. You can either use pre-defined keys where conversion takes place without extra configurations, or use custom keys with which the messages can be published.</p></div>
-* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-keyvalue/api/1.0.1-SNAPSHOT/#keyvalue-source-mapper">keyvalue</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#source-mappers">Source Mapper</a>)*<br><div style="padding-left: 1em;"><p><code>Key-Value Map to Event</code> input mapper extension allows transports that accept events as key value maps to convert those events to Siddhi events. You can either receive pre-defined keys where conversion takes place without extra configurations, or use custom keys to map from the message.</p></div>
+* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-keyvalue/api/1.0.2-SNAPSHOT/#keyvalue-source-mapper">keyvalue</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#source-mappers">Source Mapper</a>)*<br><div style="padding-left: 1em;"><p><code>Key-Value Map to Event</code> input mapper extension allows transports that accept events as key value maps to convert those events to Siddhi events. You can either receive pre-defined keys where conversion takes place without extra configurations, or use custom keys to map from the message.</p></div>
+* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-map-keyvalue/api/1.0.2-SNAPSHOT/#keyvalue-sink-mapper">keyvalue</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#sink-mappers">Sink Mapper</a>)*<br><div style="padding-left: 1em;"><p>The <code>Event to Key-Value Map</code> output mapper extension allows you to convert Siddhi events processed by WSO2 SP to key-value map events before publishing them. You can either use pre-defined keys where conversion takes place without extra configurations, or use custom keys with which the messages can be published.</p></div>
 
 ## How to Contribute
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,6 @@ pages:
 - Welcome to WSO2 Siddhi Map KeyValue: index.md
 - API Docs:
   - 1.0.0-SNAPSHOT: api/1.0.0-SNAPSHOT.md
-  - 1.0.1-SNAPSHOT: api/1.0.1-SNAPSHOT.md
+  - 1.0.2-SNAPSHOT: api/1.0.2-SNAPSHOT.md
 - License: license.md
 theme: material

--- a/pom.xml
+++ b/pom.xml
@@ -93,15 +93,12 @@
                 <artifactId>maven-deploy-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.wso2.siddhi</groupId>
-                <artifactId>siddhi-doc-gen</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>generate-md-docs</goal>
-                        </goals>
-                    </execution>
-                </executions>
+               <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <preparationGoals>clean install -Pdocumentation-deploy</preparationGoals>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                </configuration>
             </plugin>
         </plugins>
         <pluginManagement>
@@ -136,7 +133,7 @@
     </build>
 
     <properties>
-        <siddhi.version>4.0.0-M78</siddhi.version>
+        <siddhi.version>4.0.0-M104</siddhi.version>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <carbon.feature.plugin.version>3.0.0</carbon.feature.plugin.version>
         <testng.version>6.11</testng.version>


### PR DESCRIPTION
## Purpose
>To Make GitHub io site auto deploy on gh-pages.
To prepare the extension in standard way.

## Approach
> Update the siddhi version to 104.
Add relevant plugins and profile to pom.xml files to make site auto deploy on gh-pages in release build.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

