### PR TITLE
Tests for allowing strings in annotation property names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     </build>
 
     <properties>
-        <siddhi.version>4.2.17</siddhi.version>
+        <siddhi.version>4.3.18</siddhi.version>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <carbon.feature.plugin.version>3.0.0</carbon.feature.plugin.version>
         <testng.version>6.11</testng.version>


### PR DESCRIPTION
## Purpose
In Siddhi, annotation property names/keys do not allow special characters and leading numbers. This has been a limitation for some of the use cases.

This has been fixed in https://github.com/wso2/siddhi/pull/1002. 

## Goals
This PR adds relevant tests to test the fix.

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
Yes

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
https://github.com/wso2/siddhi/pull/1002

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A