### PR TITLE
Fix an issue when mapping java.sql.Timestamp to long

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/map/keyvalue/sourcemapper/KeyValueSourceMapper.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/map/keyvalue/sourcemapper/KeyValueSourceMapper.java
@@ -208,6 +208,8 @@ public class KeyValueSourceMapper extends SourceMapper {
                         data[position] = ((BigInteger) value).intValue();
                     } else if (value instanceof BigDecimal) {
                         data[position] = ((BigDecimal) value).intValue();
+                    } else if (value instanceof Timestamp) {
+                        data[position] = ((Timestamp) value).getTime();
                     } else {
                         log.error("Message " + keyValueEvent.toString() +
                                 " contains incompatible attribute types and values. Value " +


### PR DESCRIPTION
## Purpose
Fix an issue when mapping java.sql.Timestamp to long

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
