### PR TITLE
Fix missing param in AttributeMapping

### DIFF
--- a/component/src/main/java/io/siddhi/extension/map/keyvalue/sourcemapper/KeyValueSourceMapper.java
+++ b/component/src/main/java/io/siddhi/extension/map/keyvalue/sourcemapper/KeyValueSourceMapper.java
@@ -121,7 +121,8 @@ public class KeyValueSourceMapper extends SourceMapper {
             this.attributeMappingList = new ArrayList<>(streamDefinition.getAttributeList().size());
             for (int i = 0; i < attributesSize; i++) {
                 String name = this.streamDefinition.getAttributeList().get(i).getName();
-                this.attributeMappingList.add(new AttributeMapping(name, i, name));
+                Attribute.Type type = this.streamDefinition.getAttributeList().get(i).getType();
+                this.attributeMappingList.add(new AttributeMapping(name, i, name, type));
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     </build>
 
     <properties>
-        <siddhi.version>5.1.5</siddhi.version>
+        <siddhi.version>5.1.12</siddhi.version>
         <siddhi.version.range>[5.0.0,6.0.0)</siddhi.version.range>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <carbon.feature.plugin.version>3.0.0</carbon.feature.plugin.version>


### PR DESCRIPTION
## Purpose
When using the `keyvalue` source mapper, following exception throws.

```
...
Caused by: java.lang.NoSuchMethodError: io.siddhi.core.stream.input.source.AttributeMapping.<init>(Ljava/lang/String;ILjava/lang/String;)V
	at io.siddhi.extension.map.keyvalue.sourcemapper.KeyValueSourceMapper.init(KeyValueSourceMapper.java:124)
	at io.siddhi.core.stream.input.source.SourceMapper.init(SourceMapper.java:81)
	at io.siddhi.core.stream.input.source.Source.init(Source.java:74)
	at io.siddhi.core.util.parser.helper.DefinitionParserHelper.addEventSource(DefinitionParserHelper.java:372)
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes